### PR TITLE
Updated template, virtual_sdcard and readme to reflect recent mailsail/klipper changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ Structured Klipper config for Prusa MK3s/MK3s+ 3D printer, inspired by https://g
 1. Install https://docs.mainsail.xyz/setup/mainsail-os to SDCard and RPI Zero 2 W
 2. Connect as described in https://help.prusa3d.com/en/article/raspberry-pi-zero-w-preparation-and-installation_2180
 3. Update all components under Machine tab, otherwise config might not be able to load
-4. Clone config ```git clone https://github.com/dz0ny/klipper-prusa-mk3s.git ~/klipper_config/config```
+4. Clone config ```git clone https://github.com/dz0ny/klipper-prusa-mk3s.git ~/printer_data/klipper-prusa-mk3s```
 5. Add the following to the to `moonraker.conf` to enable automatic updates
 
 ```yml
 [update_manager prusa]
 type: git_repo
 origin: https://github.com/dz0ny/klipper-prusa-mk3s.git
-path: ~/klipper_config/config
+path: ~/printer_data/klipper-prusa-mk3s
 primary_branch: main
 is_system_service: False
 managed_services: klipper

--- a/mk3s/einsy-rambo.cfg
+++ b/mk3s/einsy-rambo.cfg
@@ -142,7 +142,7 @@ switch_pin: !PK0
 [input_shaper]
 
 [virtual_sdcard]
-path: ~/gcode_files
+path: ~/printer_data/gcodes
 
 [display_status]
 

--- a/printer.template.cfg
+++ b/printer.template.cfg
@@ -26,23 +26,23 @@ serial: /dev/serial0  # If you are using internal RPI serial port
 restart_method: command
 
 ### CONTROL BOARD
-[include config/mk3s/einsy-rambo.cfg]
+[include klipper-prusa-mk3s/mk3s/einsy-rambo.cfg]
 
 ### BASE SETUP
-[include config/mk3s/display.cfg]
-[include config/mk3s/steppers.cfg]
-[include config/mk3s/tmc2130.cfg]
+[include klipper-prusa-mk3s/mk3s/display.cfg]
+[include klipper-prusa-mk3s/mk3s/steppers.cfg]
+[include klipper-prusa-mk3s/mk3s/tmc2130.cfg]
 
 ### EXTRUSION
 
 # Extruder
-[include config/extruders/prusa.cfg]
-# [include config/extruders/bmg.cfg]
+[include klipper-prusa-mk3s/extruders/prusa.cfg]
+# [include klipper-prusa-mk3s/extruders/bmg.cfg]
 
 # Hotend
-[include config/hotends/v6.cfg]
-# [include config/hotends/dragon-standard-flow.cfg]
-# [include config/hotends/rapido.cfg]
+[include klipper-prusa-mk3s/hotends/v6.cfg]
+# [include klipper-prusa-mk3s/hotends/dragon-standard-flow.cfg]
+# [include klipper-prusa-mk3s/hotends/rapido.cfg]
 
 [extruder]
 # To tune Pressure Advance see https://www.klipper3d.org/Pressure_Advance.html
@@ -80,7 +80,7 @@ nozzle_diameter: 0.4 # Remember to change this if you change nozzle diameter.
 
 # 
 ### MACROS
-[include config/macros.cfg]
+[include klipper-prusa-mk3s/macros.cfg]
 
 # First run
 # PID_CALIBRATE HEATER=extruder TARGET=170


### PR DESCRIPTION
MainsailOS has moved configurations from `$HOME/klipper_config` to `$HOME/printer_data/config`, which has repercussions on how config files are loaded. When adding Klipper to my printer, I experienced a lot of errors as files were no longer where they were expected. Likewise, specifying `include ../klipper_config/{name_of_module}` also was not possible, as backwards path traversal when evaluating path names seems to not be possible.

I also experienced an error with `[virtual_sdcard]`, as the `$HOME/gcode_files` is not a path Mainsail uses, and uploading files would cause files to be generated to `printer_data/gcodes` instead, causing a very annoying `File could not be opened` error every time I pushed gcode.

Also more annoying, only the first loaded value of `[virtual_sdcard]` would resolve, and trying to override it in `printer.cfg` would cause a warning in Mainsail that there's a bad configuration, and that `$HOME/gcode_files` (which in my case was `/home/klipper/gcode_files`) is not accessible.

### Changes

- To make it easier for new users, I've updated the printer config template to use the correct relative path within `printer_data`
- I've updated the README to inform new users that they should be cloning to a location within `$HOME/printer_data` instead of directly in `$HOME` (Mainsail seems to lock loading files that aren't within the `printer_data` directory
- I've updated the `mk3s/einsy-rambo.cfg` file to use the correct Mainsail path that both the Octoprint Compat module and Web interface adds and remove gcode (which is now `$HOME/printer_data/gcodes`)