### PR TITLE
enable stealthchop threshold for extruder

### DIFF
--- a/mk3s/tmc2130.cfg
+++ b/mk3s/tmc2130.cfg
@@ -81,3 +81,4 @@ driver_PWM_GRAD: 4
 driver_PWM_AMPL: 240
 driver_PWM_AUTOSCALE: True
 driver_SGT: 3
+stealthchop_threshold: 403


### PR DESCRIPTION
Prusa marlin firmware enable stealthchop by default for extruder (normal and stealth mode).

It allows to run extruder in a more silent state, b i'm not 100% sure about the unit of the threshold though.

https://github.com/prusa3d/Prusa-Firmware/blob/2dcaae80d547259d17ae3b0aaaa11685d3168ef2/Firmware/tmc2130.cpp#L202 https://github.com/prusa3d/Prusa-Firmware/blob/2dcaae80d547259d17ae3b0aaaa11685d3168ef2/Firmware/variants/1_75mm_MK3S-EINSy10a-E3Dv6full.h#L266