### PR TITLE
feat: add LCD backlight control

### DIFF
--- a/mk3s/display.cfg
+++ b/mk3s/display.cfg
@@ -2,6 +2,14 @@
 # To override settings from this file, you can copy and paste the relevant
 # sections into your printer.cfg and change it there.
 
+[output_pin LCD_backlight_pin]
+pin: PE3
+pwm: True
+hardware_pwm: True
+
+value: 0.01       # 1% of backlight
+shutdown_value: 1 # Back to full backlight (without PWM) on restart
+cycle_time: 0.001 # Default 0.1s cycle time flickers as hell
 
 [display]
 lcd_type: hd44780


### PR DESCRIPTION
PE3 pin is wired to LCD backlight control on MK3S/+.
Prusa firmware implementation can bee seen here:
https://github.com/prusa3d/Prusa-Firmware/pull/2270