### PR TITLE
Corrected linear correction path

### DIFF
--- a/printer.template.cfg
+++ b/printer.template.cfg
@@ -81,7 +81,7 @@ pid_Kd: 139.595
 
 # Linear correction
 # Check `extruders/linear-correction` for more informations.
-[include extruder/linear-correction/linear-correction-0.cfg] # Default Prusa linear correction optimized for LDO motors
+[include klipper-prusa-mk3s/extruders/linear-correction/linear-correction-0.cfg] # Default Prusa linear correction optimized for LDO motors
 
 ### MACROS
 [include klipper-prusa-mk3s/macros.cfg]


### PR DESCRIPTION
The path for linear-correction-0.cfg in the template is relative to the local directory, and refers to an 'extruder' directory, not 'extruders'. Since the template should be copied into the local printer config, I updated the path to include the repo name, like the other paths specified in the template.