### PR TITLE
Update einsy-rambo.cfg - Screw names and punctuation.

### DIFF
--- a/mk3s/einsy-rambo.cfg
+++ b/mk3s/einsy-rambo.cfg
@@ -24,21 +24,21 @@ resolution: 0.25
 screw1: 13,6
 screw1_name: Front Left
 screw2: 13,115
-screw1_name: Front Center
+screw2_name: Front Center
 screw3: 13,210
 screw3_name: Front Right
 
 screw4: 123,6
-screw1_name: Center Left
+screw4_name: Center Left
 screw5: 123,210
-screw3_name: Center Right
+screw5_name: Center Right
 
 screw6: 228,6
-screw3_name: Back Left
+screw6_name: Back Left
 screw7: 228,115
-screw1_name: Back Center
+screw7_name: Back Center
 screw8: 228,210
-screw3_name: Back Right
+screw8_name: Back Right
 
 [extruder]
 nozzle_diameter: 0.400
@@ -70,7 +70,7 @@ fan_speed: 1.0
 [fan]
 pin: PH3
 
-# These are only safeguards for first time users
+# These are only safeguards for first time users.
 # Modify printer.cfg to tune acceleration.
 [printer]
 kinematics: cartesian


### PR DESCRIPTION
Screw names were incorrect seemingly stemming from copying and pasting lines when building the file. 

This PR ensures that [screw#] and [screw#_name] match.