### PR TITLE
Update printer.template.cfg

### DIFF
--- a/printer.template.cfg
+++ b/printer.template.cfg
@@ -46,6 +46,7 @@ restart_method: command
 # To tune Pressure Advance see https://www.klipper3d.org/Pressure_Advance.html
 # default is already set based on hotend, but you can further improve prints by calibrating it to your nozzle and material
 # pressure_advance: 0.05
+control: pid
 nozzle_diameter: 0.4 # Remember to change this if you change nozzle diameter.
 pid_Kp: 23.862
 pid_Ki: 1.020
@@ -94,8 +95,6 @@ pid_Kd: 139.595
 # SAVE_CONFIG
 
 # You can also skip the above setting for stock Prusa and use
-[extruder]
-control: pid
 # min_temp: 0
 # max_temp: 305
 # min_extrude_temp: 170

--- a/printer.template.cfg
+++ b/printer.template.cfg
@@ -94,8 +94,8 @@ pid_Kd: 139.595
 # SAVE_CONFIG
 
 # You can also skip the above setting for stock Prusa and use
-# [extruder]
-# control: pid
+[extruder]
+control: pid
 # min_temp: 0
 # max_temp: 305
 # min_extrude_temp: 170


### PR DESCRIPTION
Klipper requires you to have "control" configured before you can even connect to the printer, so the "FIRST RUN" instructions appear to be incorrect.